### PR TITLE
Add gitlab and github agent development templates

### DIFF
--- a/projects/agent-building-template/github/.github/workflows/build-and-push.yaml
+++ b/projects/agent-building-template/github/.github/workflows/build-and-push.yaml
@@ -1,0 +1,50 @@
+name: Create and publish a Docker image
+
+on:
+  push
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/projects/agent-building-template/github/Dockerfile
+++ b/projects/agent-building-template/github/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY * /app
+RUN pip install -r requirements.txt
+CMD python entrypoint.py

--- a/projects/agent-building-template/github/README.md
+++ b/projects/agent-building-template/github/README.md
@@ -1,0 +1,63 @@
+# agent-development
+
+## Getting started
+
+This is a template project for getting started with agentic AI development
+
+## Contents
+
+### agent.py
+
+This is where the agent code can start. Other files from the template depend on this to be where the agent is
+initialized, but more files can be added to support proper programming hygiene.
+
+### agent_entry.py
+
+This provides the API entrypoint for the agent through the decorator.
+
+### api_manager.py
+
+This creates the decorator
+
+### entrypoint.py
+
+This is the entrypoint to running the agent using the API. You can run it locally with `python entrypoint.py`. It's also
+what the Dockerfile uses as the `CMD`.
+
+### Dockerfile
+
+The Dockerfile is a skeleton Dockerfile that should have most of the features you already need. You may have to update
+the python version used in the base image.
+
+### requirements.txt
+
+This file has the python requirements needed to use the agent. It is an empty file and will need to be filled as the
+agent is developed and new libraries are added. Rather than running `pip install $LIBRARY`, it is suggested to put the
+library in the `requirements.txt`, with its version, and run `pip install -r requirements.txt` during development.
+
+### deployment.yaml
+
+This file is to allow you to deploy your agent into the Kubernetes environment. You will need to update the $IMAGE_NAME
+to the correct format for the registry.
+
+### .github/workflows/build-and-push.yaml
+
+This file tells Github to build and push the agent into Github container registry.
+
+## How to use
+
+- Create an empty Github repo
+- Create
+  a [Github token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
+  for pulling from Github Container Registry.
+- Create a service account for your agent `kubectl create service account agent-serviceaccount`
+- Create a docker secret in kubernetes for this token: `kubectl create secret docker-registry ghcr-login-secret --docker-server=https://ghcr.io --docker-username=$YOUR_GITHUB_USERNAME --docker-password=$YOUR_GITHUB_TOKEN --docker-email=$YOUR_EMAIL`
+- Add the secret to your service account `kubectl patch serviceaccount agent-serviceaccount -p '{"imagePullSecrets": [{"name": "ghcr-login-secret"}]}'`
+- Git clone this repository
+- Develop your agent starting in `agent.py`. Make sure to add any requirements to `requirements.txt` along the way.
+- Git commit and git push this repo to the Github repo
+- Github will automatically build your agent and produce the `IMAGE_PATH` needed for the `deployment.yaml`.
+- Update the `IMAGE_PATH` in `deployment.yaml` and `kubectl apply -f deployment.yaml` into your Kubernetes environment.
+- Your agent should deploy and start.
+- `kubectl port-forward svc/agent 8000`
+- Send a request to `localhost:8000` and it should be processed by your agent.

--- a/projects/agent-building-template/github/agent.py
+++ b/projects/agent-building-template/github/agent.py
@@ -1,0 +1,12 @@
+import json
+
+
+class MyAgent:
+    # init code in here, possibly the model and any callbacks
+    def __init__(self):
+        pass
+
+
+    def run(self, request):
+        response = ""  # Add the code in here to actually run a generation on the request.
+        return {"response": response}

--- a/projects/agent-building-template/github/agent_entry.py
+++ b/projects/agent-building-template/github/agent_entry.py
@@ -1,0 +1,14 @@
+from agent import MyAgent
+from api_manager import endpoint
+from pydantic import BaseModel
+
+agent = MyAgent()
+
+
+class Request(BaseModel):
+    request: str
+
+
+@endpoint(method="post")
+def request(request: Request):
+    return agent.run(request.request)

--- a/projects/agent-building-template/github/api_manager.py
+++ b/projects/agent-building-template/github/api_manager.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+
+class APIManager:
+    def __init__(self):
+        self.app = FastAPI()
+
+    def endpoint(self, route="/", method="post"):
+        """
+        Decorator that registers a function as a FastAPI endpoint.
+        """
+
+        def decorator(func):
+            getattr(self.app, method.lower())(route)(func)
+            return func
+
+        return decorator
+
+
+# Create the singleton instance
+manager = APIManager()
+endpoint = manager.endpoint  # Export the decorator directly
+app = manager.app  # Export the app for uvicorn

--- a/projects/agent-building-template/github/deployment.yaml
+++ b/projects/agent-building-template/github/deployment.yaml
@@ -1,0 +1,41 @@
+# Used for registry credentials/pod identity
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-serviceaccount
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent
+  labels:
+    app: agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+        - name: agent
+          image: $IMAGE_NAME
+          ports:
+            - containerPort: 8000
+      serviceAccountName: agent-serviceaccount
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app: agent

--- a/projects/agent-building-template/github/entrypoint.py
+++ b/projects/agent-building-template/github/entrypoint.py
@@ -1,0 +1,9 @@
+import uvicorn
+# Import routes to register them
+import agent_entry
+from api_manager import manager
+
+# Export the app
+app = manager.app
+
+uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/projects/agent-building-template/github/requirements.txt
+++ b/projects/agent-building-template/github/requirements.txt
@@ -1,0 +1,5 @@
+# Requirements for the API Server
+fastapi==0.116.1
+uvicorn==0.35.0
+
+# Requirements for the agent

--- a/projects/agent-building-template/gitlab/.gitlab-ci.yml
+++ b/projects/agent-building-template/gitlab/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+build-rootless:
+  image: moby/buildkit:rootless
+  stage: build
+  variables:
+    BUILDKITD_FLAGS: --oci-worker-no-process-sandbox
+  before_script:
+    - mkdir -p ~/.docker
+    - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > ~/.docker/config.json
+  script:
+    - |
+      buildctl-daemonless.sh build \
+        --frontend dockerfile.v0 \
+        --local context=. \
+        --local dockerfile=. \
+        --output type=image,name=$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA,push=true

--- a/projects/agent-building-template/gitlab/Dockerfile
+++ b/projects/agent-building-template/gitlab/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY * /app
+RUN pip install -r requirements.txt
+CMD python entrypoint.py

--- a/projects/agent-building-template/gitlab/README.md
+++ b/projects/agent-building-template/gitlab/README.md
@@ -1,0 +1,57 @@
+# agent-development
+
+## Getting started
+
+This is a template project for getting started with agentic AI development
+
+## Contents
+
+### agent.py
+
+This is where the agent code can start. Other files from the template depend on this to be where the agent is
+initialized, but more files can be added to support proper programming hygiene.
+
+### agent_entry.py
+
+This provides the API entrypoint for the agent through the decorator.
+
+### api_manager.py
+
+This creates the decorator
+
+### entrypoint.py
+
+This is the entrypoint to running the agent using the API. You can run it locally with `python entrypoint.py`. It's also
+what the Dockerfile uses as the `CMD`.
+
+### Dockerfile
+
+The Dockerfile is a skeleton Dockerfile that should have most of the features you already need. You may have to update
+the python version used in the base image.
+
+### requirements.txt
+
+This file has the python requirements needed to use the agent. It is an empty file and will need to be filled as the
+agent is developed and new libraries are added. Rather than running `pip install $LIBRARY`, it is suggested to put the
+library in the `requirements.txt`, with its version, and run `pip install -r requirements.txt` during development.
+
+### deployment.yaml
+
+This file is to allow you to deploy your agent into the Kubernetes environment. You will need to update the $IMAGE_NAME
+to the correct format for the registry.
+
+### .gitlab-ci.yaml
+
+This file tells Gitlab to build and push the agent into the internal Gitlab container registry.
+
+## How to use
+
+- Create an empty Gitlab project
+- Git clone this repository
+- Develop your agent starting in `agent.py`. Make sure to add any requirements to `requirements.txt` along the way.
+- Git commit and git push this repo to the Gitlab project
+- Gitlab will automatically build your agent and produce the `IMAGE_PATH` needed for the `deployment.yaml`.
+- Update the `IMAGE_PATH` in `deployment.yaml` and `kubectl apply -f deployment.yaml` into your Kubernetes environment.
+- Your agent should deploy and start.
+- `kubectl port-forward svc/agent 8000`
+- Send a request to `localhost:8000` and it should be processed by your agent.

--- a/projects/agent-building-template/gitlab/agent.py
+++ b/projects/agent-building-template/gitlab/agent.py
@@ -1,0 +1,12 @@
+import json
+
+
+class MyAgent:
+    # init code in here, possibly the model and any callbacks
+    def __init__(self):
+        pass
+
+
+    def run(self, request):
+        response = ""  # Add the code in here to actually run a generation on the request.
+        return {"response": response}

--- a/projects/agent-building-template/gitlab/agent_entry.py
+++ b/projects/agent-building-template/gitlab/agent_entry.py
@@ -1,0 +1,14 @@
+from agent import MyAgent
+from api_manager import endpoint
+from pydantic import BaseModel
+
+agent = MyAgent()
+
+
+class Request(BaseModel):
+    request: str
+
+
+@endpoint(method="post")
+def request(request: Request):
+    return agent.run(request.request)

--- a/projects/agent-building-template/gitlab/api_manager.py
+++ b/projects/agent-building-template/gitlab/api_manager.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+
+
+class APIManager:
+    def __init__(self):
+        self.app = FastAPI()
+
+    def endpoint(self, route="/", method="post"):
+        """
+        Decorator that registers a function as a FastAPI endpoint.
+        """
+
+        def decorator(func):
+            getattr(self.app, method.lower())(route)(func)
+            return func
+
+        return decorator
+
+
+# Create the singleton instance
+manager = APIManager()
+endpoint = manager.endpoint  # Export the decorator directly
+app = manager.app  # Export the app for uvicorn

--- a/projects/agent-building-template/gitlab/deployment.yaml
+++ b/projects/agent-building-template/gitlab/deployment.yaml
@@ -1,0 +1,41 @@
+# Used for registry credentials/pod identity
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-serviceaccount
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent
+  labels:
+    app: agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+        - name: agent
+          image: $IMAGE_NAME
+          ports:
+            - containerPort: 8000
+      serviceAccountName: agent-serviceaccount
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app: agent

--- a/projects/agent-building-template/gitlab/entrypoint.py
+++ b/projects/agent-building-template/gitlab/entrypoint.py
@@ -1,0 +1,9 @@
+import uvicorn
+# Import routes to register them
+import agent_entry
+from api_manager import manager
+
+# Export the app
+app = manager.app
+
+uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/projects/agent-building-template/gitlab/requirements.txt
+++ b/projects/agent-building-template/gitlab/requirements.txt
@@ -1,0 +1,5 @@
+# Requirements for the API Server
+fastapi==0.116.1
+uvicorn==0.35.0
+
+# Requirements for the agent


### PR DESCRIPTION
This PR adds the agent building templates and workflows for Github and Gitlab. This allows anyone to clone the templates and start building agents that can be automatically built and pushed to either Github or Gitlab container registries.